### PR TITLE
Miami Game Jam name changed to MIA Game Jam

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@ xmlns:fb="http://ogp.me/ns/fb#">
                     </a> -->
                 </div>
                 <div class="col-xs-8 col-md-7">
-                  <h1>Miami GameJam</h1>
+                  <h1>MIA Game Jam</h1>
                   <h3>Miami Dade College</h3>
                   <h3>Miami, FL</h3>
                 </div>


### PR DESCRIPTION
Changed Game Jam name from "Miami Game Jam" to the name "MIA Game Jam." It is part of a larger conference "MIA Animation Festival" so keeping the MIA part of the branding is important. Thank you!
